### PR TITLE
Bump h5 font size up to 22px

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -12,7 +12,7 @@ h2, h4 {
 }
 h5 {
 	font-weight: 300;
-	font-size: 20px;
+	font-size: 22px;
 }
 li {
 	padding: 25px 0;


### PR DESCRIPTION
This PR updates updates the font-size of the h5 from 20px to 22px.